### PR TITLE
Add CoinGecko Flask dashboard example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,38 @@
 # genai
+
+## CoinGecko UI Examples
+
+This repository contains example scripts that fetch data from the [CoinGecko](https://www.coingecko.com/) API.
+One example uses Tkinter to display data in a desktop window and another serves a simple dashboard using Flask.
+
+### Tkinter example
+
+1. Ensure Python 3 and the `requests` library are available:
+
+   ```bash
+   pip install requests
+   ```
+
+2. Run the script:
+
+   ```bash
+   python3 coingecko_ui.py
+   ```
+
+A window will open showing the rank, name and current price of the top cryptocurrencies.
+
+### Flask dashboard
+
+Install the required libraries if you haven't already:
+
+```bash
+pip install flask requests
+```
+
+Start the web server:
+
+```bash
+python3 coingecko_dashboard.py
+```
+
+Open `http://localhost:5000` in your browser to see the table of top coins.

--- a/coingecko_dashboard.py
+++ b/coingecko_dashboard.py
@@ -1,0 +1,59 @@
+from flask import Flask, render_template_string
+import requests
+
+app = Flask(__name__)
+
+TEMPLATE = '''
+<!DOCTYPE html>
+<html>
+<head>
+    <title>CoinGecko Top Coins</title>
+    <style>
+        table { border-collapse: collapse; width: 60%; margin: auto; }
+        th, td { border: 1px solid #ccc; padding: 8px 12px; text-align: left; }
+        th { background-color: #f5f5f5; }
+    </style>
+</head>
+<body>
+    <h2 style="text-align:center;">Top {{ coins|length }} Cryptocurrencies</h2>
+    <table>
+        <tr><th>Rank</th><th>Name</th><th>Price (USD)</th></tr>
+        {% for coin in coins %}
+        <tr>
+            <td>{{ coin.market_cap_rank }}</td>
+            <td>{{ coin.name }}</td>
+            <td>${{ "{:,.2f}".format(coin.current_price) }}</td>
+        </tr>
+        {% endfor %}
+    </table>
+</body>
+</html>
+'''
+
+
+def fetch_top_coins(limit=10):
+    url = "https://api.coingecko.com/api/v3/coins/markets"
+    params = {
+        "vs_currency": "usd",
+        "order": "market_cap_desc",
+        "per_page": limit,
+        "page": 1,
+        "sparkline": "false",
+    }
+    resp = requests.get(url, params=params, timeout=10)
+    resp.raise_for_status()
+    return resp.json()
+
+
+@app.route("/")
+def index():
+    try:
+        coins = fetch_top_coins()
+    except requests.RequestException as exc:
+        coins = []
+        print(f"Error fetching data: {exc}")
+    return render_template_string(TEMPLATE, coins=coins)
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/coingecko_ui.py
+++ b/coingecko_ui.py
@@ -1,0 +1,41 @@
+import requests
+import tkinter as tk
+from tkinter import ttk, messagebox
+
+
+def fetch_top_coins(limit=10):
+    url = "https://api.coingecko.com/api/v3/coins/markets"
+    params = {
+        "vs_currency": "usd",
+        "order": "market_cap_desc",
+        "per_page": limit,
+        "page": 1,
+        "sparkline": "false",
+    }
+    response = requests.get(url, params=params, timeout=10)
+    response.raise_for_status()
+    return response.json()
+
+
+def main():
+    root = tk.Tk()
+    root.title("CoinGecko Top Coins")
+
+    tree = ttk.Treeview(root, columns=("rank", "name", "price"), show="headings")
+    tree.heading("rank", text="Rank")
+    tree.heading("name", text="Name")
+    tree.heading("price", text="Price (USD)")
+    tree.pack(fill=tk.BOTH, expand=True)
+
+    try:
+        coins = fetch_top_coins()
+        for coin in coins:
+            tree.insert("", tk.END, values=(coin["market_cap_rank"], coin["name"], f"${coin['current_price']:,}"))
+    except requests.RequestException as exc:
+        messagebox.showerror("Error", f"Failed to load data: {exc}")
+
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `coingecko_dashboard.py` serving data in a Flask web page
- update README with instructions for both Tkinter and Flask examples

## Testing
- ❌ `python3 coingecko_dashboard.py` (failed to run: `ModuleNotFoundError: No module named 'flask'`)
- ❌ `pip install flask requests` (failed due to network restrictions)

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68443bc6f4788323ba6646c8d0c8ac71